### PR TITLE
Fix keyboard bugs in a portable way

### DIFF
--- a/docs/reference/denemo/denemo-sections.txt
+++ b/docs/reference/denemo/denemo-sections.txt
@@ -745,9 +745,6 @@ free_jack_ports
 <SECTION>
 <FILE>kbd-custom</FILE>
 MASK_FILTER
-dnm_sanitize_key_event
-dnm_hyper_sanitize_key_event
-dnm_meta_sanitize_key_state
 isModifier
 dnm_accelerator_parse
 dnm_accelerator_name
@@ -804,7 +801,6 @@ command_has_binding
 add_keybinding_for_name
 add_keybinding_for_command
 update_all_labels
-dnm_clean_event
 add_twokeybinding_to_idx
 command_row_init
 keymap_get_command_row

--- a/src/command/keyresponses.c
+++ b/src/command/keyresponses.c
@@ -178,7 +178,7 @@ process_key_event (GdkEventKey * event, gchar * perform_command ())
     if (state || ((event->keyval == GDK_Caps_Lock) || (event->keyval == GDK_Num_Lock)))
       set_cursor_for (state);   // MUST LOOK AHEAD to state after keypress HERE CATCH modifiers and set the cursor for them.....
   }
-  dnm_clean_event (event);
+  dnm_sanitize_key_state (event);
   static guint last_keyval;
   gboolean repeated_key =  (event->keyval==last_keyval);
   last_keyval = event->keyval;
@@ -343,7 +343,7 @@ scorearea_keypress_event (GtkWidget * widget, GdkEventKey * event)
   //g_debug("State eored %x\n", (lock_mask(event->keyval)^event->state));
   if (divert_key_event && !isModifier (event) && divert_key_id == Denemo.project->id)
     {
-      dnm_clean_event (event);
+      dnm_sanitize_key_state (event);
       *divert_key_event = event;
       //g_object_ref(event); FIXME do we need to keep it around?
       gtk_main_quit ();

--- a/src/core/kbd-custom.h
+++ b/src/core/kbd-custom.h
@@ -35,7 +35,6 @@ typedef struct _keyboard_dialog_data
   gint first_modifiers;
 } keyboard_dialog_data;
 
-guint dnm_sanitize_key_event (GdkEventKey * event);
 gboolean isModifier (GdkEventKey * event);
 
 //adapted from gtk because we want to allow uppercase accelerator through
@@ -151,7 +150,6 @@ gint add_keybinding_for_name (gchar * name, gchar * binding);
 gint add_keybinding_for_command (gint idx, gchar * binding);
 
 void update_all_labels (keymap * the_keymap);
-void dnm_clean_event (GdkEventKey * event);
 gint add_twokeybinding_to_idx (keymap * the_keymap, gint first_keyval, GdkModifierType first_state, gint keyval, GdkModifierType state, guint command_id, ListPosition pos);
 
 void command_row_init(command_row *command);

--- a/src/ui/kbd-interface.c
+++ b/src/ui/kbd-interface.c
@@ -76,7 +76,6 @@ capture_add_binding (GtkWidget * widget, GdkEventKey * event, gpointer user_data
   //get the shortcut
   if (isModifier (event))
     return TRUE;
-  dnm_clean_event (event);
   modifiers = dnm_sanitize_key_state (event);
   gchar *name = dnm_accelerator_name (event->keyval, event->state);
   if (!strcmp(name, "VoidSymbol"))
@@ -161,7 +160,6 @@ capture_look_binding (GtkWidget * widget, GdkEventKey * event, gpointer user_dat
   //get the shortcut
   if (isModifier (event))
     return TRUE;
-  dnm_clean_event (event);
   modifiers = dnm_sanitize_key_state (event);
 
   //look for the keybinding


### PR DESCRIPTION
- Remove unused dnm_sanitize_key_event () prototype
- Remove dnm_clean_event () altogether, and combine logic into
  dnm_sanitize_key_state (), which just returned event->state
  if (!Denemo.prefs.strictshortcuts)
- Remove all calls to dnm_clean_event (); replace by
  dnm_sanitize_key_state ()
- Implement portable logic to always take as command input the "level 0"
  unmodified value of a key, passing event->hardware_keycode to
  gdk_keymap_get_entries_for_keycode() and grabbing the first keyval in
  the returned array regardless of modifier keys. See GDK docs here:
  https://developer.gnome.org/gdk3/stable/gdk3-Keyboard-Handling.html#gdk-keymap-get-entries-for-keycode